### PR TITLE
Add support for YML radish-styled cr2w dumps

### DIFF
--- a/WolvenKit/Forms/frmCR2WtoText.Designer.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.Designer.cs
@@ -29,12 +29,13 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmCR2WtoText));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
             this.btnRun = new System.Windows.Forms.Button();
             this.rtfDescription = new System.Windows.Forms.RichTextBox();
             this.pnlControls = new System.Windows.Forms.Panel();
+            this.chkDumpYML = new System.Windows.Forms.CheckBox();
             this.chkDumpOnlyEdited = new System.Windows.Forms.CheckBox();
             this.chkLocalizedString = new System.Windows.Forms.CheckBox();
             this.labNumThreads = new System.Windows.Forms.Label();
@@ -69,7 +70,6 @@
             this.colSkipped = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colExceptions = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.txtLog = new System.Windows.Forms.TextBox();
-            this.chkDumpYML = new System.Windows.Forms.CheckBox();
             this.pnlControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numThreads)).BeginInit();
             this.grpExistingFiles.SuspendLayout();
@@ -136,6 +136,19 @@
             this.pnlControls.Name = "pnlControls";
             this.pnlControls.Size = new System.Drawing.Size(987, 386);
             this.pnlControls.TabIndex = 21;
+            // 
+            // chkDumpYML
+            // 
+            this.chkDumpYML.AutoSize = true;
+            this.chkDumpYML.Checked = true;
+            this.chkDumpYML.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkDumpYML.Location = new System.Drawing.Point(604, 202);
+            this.chkDumpYML.Margin = new System.Windows.Forms.Padding(4);
+            this.chkDumpYML.Name = "chkDumpYML";
+            this.chkDumpYML.Size = new System.Drawing.Size(176, 20);
+            this.chkDumpYML.TabIndex = 39;
+            this.chkDumpYML.Text = "Dump YML (radish-style)";
+            this.chkDumpYML.UseVisualStyleBackColor = true;
             // 
             // chkDumpOnlyEdited
             // 
@@ -449,14 +462,14 @@
             this.dataStatus.AllowUserToResizeColumns = false;
             this.dataStatus.AllowUserToResizeRows = false;
             this.dataStatus.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.Disable;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataStatus.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataStatus.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle4;
             this.dataStatus.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataStatus.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.colAllFiles,
@@ -470,24 +483,24 @@
             this.dataStatus.MultiSelect = false;
             this.dataStatus.Name = "dataStatus";
             this.dataStatus.ReadOnly = true;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Info;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Info;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataStatus.RowHeadersDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Info;
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Info;
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataStatus.RowHeadersDefaultCellStyle = dataGridViewCellStyle5;
             this.dataStatus.RowHeadersVisible = false;
             this.dataStatus.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.AutoSizeToAllHeaders;
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Info;
-            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle3.Format = "N0";
-            dataGridViewCellStyle3.NullValue = "-";
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Info;
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            this.dataStatus.RowsDefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.Info;
+            dataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle6.Format = "N0";
+            dataGridViewCellStyle6.NullValue = "-";
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.Info;
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.WindowText;
+            this.dataStatus.RowsDefaultCellStyle = dataGridViewCellStyle6;
             this.dataStatus.RowTemplate.ReadOnly = true;
             this.dataStatus.RowTemplate.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.dataStatus.ScrollBars = System.Windows.Forms.ScrollBars.None;
@@ -576,19 +589,6 @@
             this.txtLog.TabStop = false;
             this.txtLog.WordWrap = false;
             // 
-            // chkDumpYML
-            // 
-            this.chkDumpYML.AutoSize = true;
-            this.chkDumpYML.Checked = true;
-            this.chkDumpYML.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkDumpYML.Location = new System.Drawing.Point(604, 202);
-            this.chkDumpYML.Margin = new System.Windows.Forms.Padding(4);
-            this.chkDumpYML.Name = "chkDumpYML";
-            this.chkDumpYML.Size = new System.Drawing.Size(176, 20);
-            this.chkDumpYML.TabIndex = 39;
-            this.chkDumpYML.Text = "Dump YML (radish-style)";
-            this.chkDumpYML.UseVisualStyleBackColor = true;
-            // 
             // frmCR2WtoText
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -606,8 +606,9 @@
             this.MinimizeBox = false;
             this.Name = "frmCR2WtoText";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Dump CR2W Files To Text";
+            this.Text = "Dump CR2W Files To Text & YML";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmCR2WtoText_FormClosing);
+            this.Load += new System.EventHandler(this.frmCR2WtoText_Load);
             this.pnlControls.ResumeLayout(false);
             this.pnlControls.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numThreads)).EndInit();

--- a/WolvenKit/Forms/frmCR2WtoText.Designer.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.Designer.cs
@@ -68,6 +68,7 @@
             this.colSkipped = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colExceptions = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.txtLog = new System.Windows.Forms.TextBox();
+            this.chkDumpOnlyEdited = new System.Windows.Forms.CheckBox();
             this.pnlControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numThreads)).BeginInit();
             this.grpExistingFiles.SuspendLayout();
@@ -81,10 +82,10 @@
             this.btnRun.Enabled = false;
             this.btnRun.Image = global::WolvenKit.Properties.Resources.Output_16x;
             this.btnRun.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnRun.Location = new System.Drawing.Point(292, 791);
-            this.btnRun.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnRun.Location = new System.Drawing.Point(260, 633);
+            this.btnRun.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnRun.Name = "btnRun";
-            this.btnRun.Size = new System.Drawing.Size(630, 35);
+            this.btnRun.Size = new System.Drawing.Size(560, 28);
             this.btnRun.TabIndex = 30;
             this.btnRun.Text = "Run CR2W Dump";
             this.btnRun.UseVisualStyleBackColor = true;
@@ -96,18 +97,19 @@
             this.rtfDescription.CausesValidation = false;
             this.rtfDescription.Cursor = System.Windows.Forms.Cursors.Default;
             this.rtfDescription.Font = new System.Drawing.Font("Calibri", 9F);
-            this.rtfDescription.Location = new System.Drawing.Point(18, 18);
-            this.rtfDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rtfDescription.Location = new System.Drawing.Point(16, 14);
+            this.rtfDescription.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rtfDescription.Name = "rtfDescription";
             this.rtfDescription.ReadOnly = true;
             this.rtfDescription.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            this.rtfDescription.Size = new System.Drawing.Size(1110, 262);
+            this.rtfDescription.Size = new System.Drawing.Size(987, 210);
             this.rtfDescription.TabIndex = 20;
             this.rtfDescription.TabStop = false;
             this.rtfDescription.Text = resources.GetString("rtfDescription.Text");
             // 
             // pnlControls
             // 
+            this.pnlControls.Controls.Add(this.chkDumpOnlyEdited);
             this.pnlControls.Controls.Add(this.chkLocalizedString);
             this.pnlControls.Controls.Add(this.labNumThreads);
             this.pnlControls.Controls.Add(this.numThreads);
@@ -127,10 +129,10 @@
             this.pnlControls.Controls.Add(this.btnChoosePath);
             this.pnlControls.Controls.Add(this.txtPath);
             this.pnlControls.Controls.Add(this.grpRadioOutputMode);
-            this.pnlControls.Location = new System.Drawing.Point(18, 295);
-            this.pnlControls.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.pnlControls.Location = new System.Drawing.Point(16, 236);
+            this.pnlControls.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlControls.Name = "pnlControls";
-            this.pnlControls.Size = new System.Drawing.Size(1110, 483);
+            this.pnlControls.Size = new System.Drawing.Size(987, 386);
             this.pnlControls.TabIndex = 21;
             // 
             // chkLocalizedString
@@ -138,10 +140,10 @@
             this.chkLocalizedString.AutoSize = true;
             this.chkLocalizedString.Checked = true;
             this.chkLocalizedString.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkLocalizedString.Location = new System.Drawing.Point(216, 352);
-            this.chkLocalizedString.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkLocalizedString.Location = new System.Drawing.Point(192, 282);
+            this.chkLocalizedString.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chkLocalizedString.Name = "chkLocalizedString";
-            this.chkLocalizedString.Size = new System.Drawing.Size(297, 24);
+            this.chkLocalizedString.Size = new System.Drawing.Size(249, 20);
             this.chkLocalizedString.TabIndex = 15;
             this.chkLocalizedString.Text = "Dump localized strings instead of IDs";
             this.chkLocalizedString.UseVisualStyleBackColor = true;
@@ -149,24 +151,24 @@
             // labNumThreads
             // 
             this.labNumThreads.AutoSize = true;
-            this.labNumThreads.Location = new System.Drawing.Point(458, 82);
+            this.labNumThreads.Location = new System.Drawing.Point(407, 66);
             this.labNumThreads.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labNumThreads.Name = "labNumThreads";
-            this.labNumThreads.Size = new System.Drawing.Size(145, 20);
+            this.labNumThreads.Size = new System.Drawing.Size(121, 16);
             this.labNumThreads.TabIndex = 37;
             this.labNumThreads.Text = "Number of threads:";
             // 
             // numThreads
             // 
-            this.numThreads.Location = new System.Drawing.Point(609, 78);
-            this.numThreads.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.numThreads.Location = new System.Drawing.Point(541, 62);
+            this.numThreads.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.numThreads.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.numThreads.Name = "numThreads";
-            this.numThreads.Size = new System.Drawing.Size(54, 26);
+            this.numThreads.Size = new System.Drawing.Size(48, 22);
             this.numThreads.TabIndex = 6;
             this.numThreads.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.numThreads.Value = new decimal(new int[] {
@@ -180,10 +182,10 @@
             this.chkCreateFolders.AutoSize = true;
             this.chkCreateFolders.Checked = true;
             this.chkCreateFolders.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkCreateFolders.Location = new System.Drawing.Point(216, 195);
-            this.chkCreateFolders.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkCreateFolders.Location = new System.Drawing.Point(192, 156);
+            this.chkCreateFolders.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chkCreateFolders.Name = "chkCreateFolders";
-            this.chkCreateFolders.Size = new System.Drawing.Size(227, 24);
+            this.chkCreateFolders.Size = new System.Drawing.Size(191, 20);
             this.chkCreateFolders.TabIndex = 10;
             this.chkCreateFolders.Text = "Create intermediate folders";
             this.chkCreateFolders.UseVisualStyleBackColor = true;
@@ -191,12 +193,10 @@
             // chkDumpEmbedded
             // 
             this.chkDumpEmbedded.AutoSize = true;
-            this.chkDumpEmbedded.Checked = true;
-            this.chkDumpEmbedded.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkDumpEmbedded.Location = new System.Drawing.Point(216, 258);
-            this.chkDumpEmbedded.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkDumpEmbedded.Location = new System.Drawing.Point(192, 206);
+            this.chkDumpEmbedded.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chkDumpEmbedded.Name = "chkDumpEmbedded";
-            this.chkDumpEmbedded.Size = new System.Drawing.Size(172, 24);
+            this.chkDumpEmbedded.Size = new System.Drawing.Size(147, 20);
             this.chkDumpEmbedded.TabIndex = 12;
             this.chkDumpEmbedded.Text = "List embedded files";
             this.chkDumpEmbedded.UseVisualStyleBackColor = true;
@@ -205,21 +205,21 @@
             // 
             this.grpExistingFiles.Controls.Add(this.radExistingSkip);
             this.grpExistingFiles.Controls.Add(this.radExistingOverwrite);
-            this.grpExistingFiles.Location = new System.Drawing.Point(216, 392);
-            this.grpExistingFiles.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpExistingFiles.Location = new System.Drawing.Point(192, 314);
+            this.grpExistingFiles.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.grpExistingFiles.Name = "grpExistingFiles";
-            this.grpExistingFiles.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.grpExistingFiles.Size = new System.Drawing.Size(213, 86);
+            this.grpExistingFiles.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grpExistingFiles.Size = new System.Drawing.Size(189, 69);
             this.grpExistingFiles.TabIndex = 20;
             this.grpExistingFiles.TabStop = false;
             // 
             // radExistingSkip
             // 
             this.radExistingSkip.AutoSize = true;
-            this.radExistingSkip.Location = new System.Drawing.Point(9, 51);
-            this.radExistingSkip.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.radExistingSkip.Location = new System.Drawing.Point(8, 41);
+            this.radExistingSkip.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.radExistingSkip.Name = "radExistingSkip";
-            this.radExistingSkip.Size = new System.Drawing.Size(154, 24);
+            this.radExistingSkip.Size = new System.Drawing.Size(131, 20);
             this.radExistingSkip.TabIndex = 22;
             this.radExistingSkip.TabStop = true;
             this.radExistingSkip.Text = "Skip existing files";
@@ -229,10 +229,10 @@
             // 
             this.radExistingOverwrite.AutoSize = true;
             this.radExistingOverwrite.Checked = true;
-            this.radExistingOverwrite.Location = new System.Drawing.Point(9, 18);
-            this.radExistingOverwrite.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.radExistingOverwrite.Location = new System.Drawing.Point(8, 14);
+            this.radExistingOverwrite.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.radExistingOverwrite.Name = "radExistingOverwrite";
-            this.radExistingOverwrite.Size = new System.Drawing.Size(189, 24);
+            this.radExistingOverwrite.Size = new System.Drawing.Size(160, 20);
             this.radExistingOverwrite.TabIndex = 21;
             this.radExistingOverwrite.TabStop = true;
             this.radExistingOverwrite.Text = "Overwrite existing files";
@@ -241,12 +241,10 @@
             // chkPrefixFileName
             // 
             this.chkPrefixFileName.AutoSize = true;
-            this.chkPrefixFileName.Checked = true;
-            this.chkPrefixFileName.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkPrefixFileName.Location = new System.Drawing.Point(216, 228);
-            this.chkPrefixFileName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkPrefixFileName.Location = new System.Drawing.Point(192, 182);
+            this.chkPrefixFileName.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chkPrefixFileName.Name = "chkPrefixFileName";
-            this.chkPrefixFileName.Size = new System.Drawing.Size(241, 24);
+            this.chkPrefixFileName.Size = new System.Drawing.Size(202, 20);
             this.chkPrefixFileName.TabIndex = 11;
             this.chkPrefixFileName.Text = "Prefix each line with file name";
             this.chkPrefixFileName.UseVisualStyleBackColor = true;
@@ -254,10 +252,10 @@
             // chkDumpFCD
             // 
             this.chkDumpFCD.AutoSize = true;
-            this.chkDumpFCD.Location = new System.Drawing.Point(216, 322);
-            this.chkDumpFCD.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkDumpFCD.Location = new System.Drawing.Point(192, 258);
+            this.chkDumpFCD.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chkDumpFCD.Name = "chkDumpFCD";
-            this.chkDumpFCD.Size = new System.Drawing.Size(205, 24);
+            this.chkDumpFCD.Size = new System.Drawing.Size(173, 20);
             this.chkDumpFCD.TabIndex = 14;
             this.chkDumpFCD.Text = "Dump flatCompiledData";
             this.chkDumpFCD.UseVisualStyleBackColor = true;
@@ -267,10 +265,10 @@
             this.chkDumpSDB.AutoSize = true;
             this.chkDumpSDB.Checked = true;
             this.chkDumpSDB.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkDumpSDB.Location = new System.Drawing.Point(216, 291);
-            this.chkDumpSDB.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkDumpSDB.Location = new System.Drawing.Point(192, 233);
+            this.chkDumpSDB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chkDumpSDB.Name = "chkDumpSDB";
-            this.chkDumpSDB.Size = new System.Drawing.Size(267, 24);
+            this.chkDumpSDB.Size = new System.Drawing.Size(219, 20);
             this.chkDumpSDB.TabIndex = 13;
             this.chkDumpSDB.Text = "Dump SharedDataBuffer buffers";
             this.chkDumpSDB.UseVisualStyleBackColor = true;
@@ -278,20 +276,20 @@
             // labOutputFileMode
             // 
             this.labOutputFileMode.AutoSize = true;
-            this.labOutputFileMode.Location = new System.Drawing.Point(82, 82);
+            this.labOutputFileMode.Location = new System.Drawing.Point(73, 66);
             this.labOutputFileMode.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labOutputFileMode.Name = "labOutputFileMode";
-            this.labOutputFileMode.Size = new System.Drawing.Size(130, 20);
+            this.labOutputFileMode.Size = new System.Drawing.Size(107, 16);
             this.labOutputFileMode.TabIndex = 30;
             this.labOutputFileMode.Text = "Output file mode:";
             this.labOutputFileMode.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // btnPickOutput
             // 
-            this.btnPickOutput.Location = new System.Drawing.Point(904, 143);
-            this.btnPickOutput.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnPickOutput.Location = new System.Drawing.Point(804, 114);
+            this.btnPickOutput.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnPickOutput.Name = "btnPickOutput";
-            this.btnPickOutput.Size = new System.Drawing.Size(112, 35);
+            this.btnPickOutput.Size = new System.Drawing.Size(100, 28);
             this.btnPickOutput.TabIndex = 8;
             this.btnPickOutput.Text = "Set output";
             this.btnPickOutput.UseVisualStyleBackColor = true;
@@ -300,10 +298,10 @@
             // labOverwrite
             // 
             this.labOverwrite.AutoSize = true;
-            this.labOverwrite.Location = new System.Drawing.Point(93, 428);
+            this.labOverwrite.Location = new System.Drawing.Point(83, 342);
             this.labOverwrite.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labOverwrite.Name = "labOverwrite";
-            this.labOverwrite.Size = new System.Drawing.Size(117, 20);
+            this.labOverwrite.Size = new System.Drawing.Size(100, 16);
             this.labOverwrite.TabIndex = 22;
             this.labOverwrite.Text = "File overwriting:";
             this.labOverwrite.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -311,10 +309,10 @@
             // labDumpOptions
             // 
             this.labDumpOptions.AutoSize = true;
-            this.labDumpOptions.Location = new System.Drawing.Point(100, 258);
+            this.labDumpOptions.Location = new System.Drawing.Point(89, 206);
             this.labDumpOptions.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labDumpOptions.Name = "labDumpOptions";
-            this.labDumpOptions.Size = new System.Drawing.Size(112, 20);
+            this.labDumpOptions.Size = new System.Drawing.Size(94, 16);
             this.labDumpOptions.TabIndex = 22;
             this.labDumpOptions.Text = "Dump options:";
             this.labDumpOptions.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -322,10 +320,10 @@
             // labOutputFile
             // 
             this.labOutputFile.AutoSize = true;
-            this.labOutputFile.Location = new System.Drawing.Point(82, 149);
+            this.labOutputFile.Location = new System.Drawing.Point(73, 119);
             this.labOutputFile.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labOutputFile.Name = "labOutputFile";
-            this.labOutputFile.Size = new System.Drawing.Size(131, 20);
+            this.labOutputFile.Size = new System.Drawing.Size(105, 16);
             this.labOutputFile.TabIndex = 23;
             this.labOutputFile.Text = "Output results to:";
             this.labOutputFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -333,29 +331,29 @@
             // labPath
             // 
             this.labPath.AutoSize = true;
-            this.labPath.Location = new System.Drawing.Point(104, 22);
+            this.labPath.Location = new System.Drawing.Point(92, 18);
             this.labPath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labPath.Name = "labPath";
-            this.labPath.Size = new System.Drawing.Size(108, 20);
+            this.labPath.Size = new System.Drawing.Size(91, 16);
             this.labPath.TabIndex = 21;
             this.labPath.Text = "Source folder:";
             this.labPath.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // txtOutputDestination
             // 
-            this.txtOutputDestination.Location = new System.Drawing.Point(216, 145);
-            this.txtOutputDestination.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.txtOutputDestination.Location = new System.Drawing.Point(192, 116);
+            this.txtOutputDestination.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtOutputDestination.Name = "txtOutputDestination";
-            this.txtOutputDestination.Size = new System.Drawing.Size(678, 26);
+            this.txtOutputDestination.Size = new System.Drawing.Size(603, 22);
             this.txtOutputDestination.TabIndex = 7;
             this.txtOutputDestination.TextChanged += new System.EventHandler(this.txtOutputDestination_TextChanged);
             // 
             // btnChoosePath
             // 
-            this.btnChoosePath.Location = new System.Drawing.Point(904, 17);
-            this.btnChoosePath.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnChoosePath.Location = new System.Drawing.Point(804, 14);
+            this.btnChoosePath.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnChoosePath.Name = "btnChoosePath";
-            this.btnChoosePath.Size = new System.Drawing.Size(112, 31);
+            this.btnChoosePath.Size = new System.Drawing.Size(100, 25);
             this.btnChoosePath.TabIndex = 2;
             this.btnChoosePath.Text = "Select path";
             this.btnChoosePath.UseVisualStyleBackColor = true;
@@ -363,10 +361,10 @@
             // 
             // txtPath
             // 
-            this.txtPath.Location = new System.Drawing.Point(216, 17);
-            this.txtPath.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.txtPath.Location = new System.Drawing.Point(192, 14);
+            this.txtPath.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtPath.Name = "txtPath";
-            this.txtPath.Size = new System.Drawing.Size(678, 26);
+            this.txtPath.Size = new System.Drawing.Size(603, 22);
             this.txtPath.TabIndex = 1;
             this.txtPath.TextChanged += new System.EventHandler(this.txtPath_TextChanged);
             // 
@@ -375,11 +373,11 @@
             this.grpRadioOutputMode.Controls.Add(this.radOutputModeSeparateFiles);
             this.grpRadioOutputMode.Controls.Add(this.radOutputModeSingleFile);
             this.grpRadioOutputMode.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.grpRadioOutputMode.Location = new System.Drawing.Point(216, 51);
-            this.grpRadioOutputMode.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpRadioOutputMode.Location = new System.Drawing.Point(192, 41);
+            this.grpRadioOutputMode.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.grpRadioOutputMode.Name = "grpRadioOutputMode";
-            this.grpRadioOutputMode.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.grpRadioOutputMode.Size = new System.Drawing.Size(213, 78);
+            this.grpRadioOutputMode.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grpRadioOutputMode.Size = new System.Drawing.Size(189, 62);
             this.grpRadioOutputMode.TabIndex = 3;
             this.grpRadioOutputMode.TabStop = false;
             // 
@@ -387,10 +385,10 @@
             // 
             this.radOutputModeSeparateFiles.AutoSize = true;
             this.radOutputModeSeparateFiles.Checked = true;
-            this.radOutputModeSeparateFiles.Location = new System.Drawing.Point(9, 17);
-            this.radOutputModeSeparateFiles.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.radOutputModeSeparateFiles.Location = new System.Drawing.Point(8, 14);
+            this.radOutputModeSeparateFiles.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.radOutputModeSeparateFiles.Name = "radOutputModeSeparateFiles";
-            this.radOutputModeSeparateFiles.Size = new System.Drawing.Size(191, 24);
+            this.radOutputModeSeparateFiles.Size = new System.Drawing.Size(161, 20);
             this.radOutputModeSeparateFiles.TabIndex = 4;
             this.radOutputModeSeparateFiles.TabStop = true;
             this.radOutputModeSeparateFiles.Text = "One file per source file";
@@ -400,10 +398,10 @@
             // radOutputModeSingleFile
             // 
             this.radOutputModeSingleFile.AutoSize = true;
-            this.radOutputModeSingleFile.Location = new System.Drawing.Point(9, 45);
-            this.radOutputModeSingleFile.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.radOutputModeSingleFile.Location = new System.Drawing.Point(8, 36);
+            this.radOutputModeSingleFile.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.radOutputModeSingleFile.Name = "radOutputModeSingleFile";
-            this.radOutputModeSingleFile.Size = new System.Drawing.Size(102, 24);
+            this.radOutputModeSingleFile.Size = new System.Drawing.Size(87, 20);
             this.radOutputModeSingleFile.TabIndex = 5;
             this.radOutputModeSingleFile.Text = "Single file";
             this.radOutputModeSingleFile.UseVisualStyleBackColor = true;
@@ -415,10 +413,10 @@
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.prgProgressBar});
             this.statusStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
-            this.statusStrip1.Location = new System.Drawing.Point(0, 1305);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 952);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Padding = new System.Windows.Forms.Padding(2, 0, 21, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(1146, 33);
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(2, 0, 19, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(1019, 28);
             this.statusStrip1.SizingGrip = false;
             this.statusStrip1.TabIndex = 25;
             this.statusStrip1.Text = "statusStrip1";
@@ -427,7 +425,7 @@
             // 
             this.prgProgressBar.Name = "prgProgressBar";
             this.prgProgressBar.Overflow = System.Windows.Forms.ToolStripItemOverflow.Always;
-            this.prgProgressBar.Size = new System.Drawing.Size(1140, 25);
+            this.prgProgressBar.Size = new System.Drawing.Size(1013, 20);
             // 
             // dataStatus
             // 
@@ -452,8 +450,8 @@
             this.colProcessedFiles,
             this.colSkipped,
             this.colExceptions});
-            this.dataStatus.Location = new System.Drawing.Point(292, 843);
-            this.dataStatus.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.dataStatus.Location = new System.Drawing.Point(260, 674);
+            this.dataStatus.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.dataStatus.MultiSelect = false;
             this.dataStatus.Name = "dataStatus";
             this.dataStatus.ReadOnly = true;
@@ -479,7 +477,7 @@
             this.dataStatus.RowTemplate.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.dataStatus.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.dataStatus.ShowEditingIcon = false;
-            this.dataStatus.Size = new System.Drawing.Size(630, 88);
+            this.dataStatus.Size = new System.Drawing.Size(560, 70);
             this.dataStatus.TabIndex = 31;
             this.dataStatus.TabStop = false;
             // 
@@ -552,22 +550,35 @@
             // txtLog
             // 
             this.txtLog.BackColor = System.Drawing.SystemColors.Window;
-            this.txtLog.Location = new System.Drawing.Point(18, 943);
-            this.txtLog.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.txtLog.Location = new System.Drawing.Point(13, 752);
+            this.txtLog.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtLog.Multiline = true;
             this.txtLog.Name = "txtLog";
             this.txtLog.ReadOnly = true;
             this.txtLog.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.txtLog.Size = new System.Drawing.Size(1108, 347);
+            this.txtLog.Size = new System.Drawing.Size(985, 226);
             this.txtLog.TabIndex = 32;
             this.txtLog.TabStop = false;
             this.txtLog.WordWrap = false;
             // 
+            // chkDumpOnlyEdited
+            // 
+            this.chkDumpOnlyEdited.AutoSize = true;
+            this.chkDumpOnlyEdited.Checked = true;
+            this.chkDumpOnlyEdited.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkDumpOnlyEdited.Location = new System.Drawing.Point(604, 156);
+            this.chkDumpOnlyEdited.Margin = new System.Windows.Forms.Padding(4);
+            this.chkDumpOnlyEdited.Name = "chkDumpOnlyEdited";
+            this.chkDumpOnlyEdited.Size = new System.Drawing.Size(178, 20);
+            this.chkDumpOnlyEdited.TabIndex = 38;
+            this.chkDumpOnlyEdited.Text = "Dump only edited values";
+            this.chkDumpOnlyEdited.UseVisualStyleBackColor = true;
+            // 
             // frmCR2WtoText
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1146, 1338);
+            this.ClientSize = new System.Drawing.Size(1019, 980);
             this.Controls.Add(this.txtLog);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.dataStatus);
@@ -575,7 +586,7 @@
             this.Controls.Add(this.btnRun);
             this.Controls.Add(this.pnlControls);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "frmCR2WtoText";
@@ -634,5 +645,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colSkipped;
         private System.Windows.Forms.DataGridViewTextBoxColumn colExceptions;
         private System.Windows.Forms.CheckBox chkLocalizedString;
+        private System.Windows.Forms.CheckBox chkDumpOnlyEdited;
     }
 }

--- a/WolvenKit/Forms/frmCR2WtoText.Designer.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.Designer.cs
@@ -35,6 +35,7 @@
             this.btnRun = new System.Windows.Forms.Button();
             this.rtfDescription = new System.Windows.Forms.RichTextBox();
             this.pnlControls = new System.Windows.Forms.Panel();
+            this.chkDumpOnlyEdited = new System.Windows.Forms.CheckBox();
             this.chkLocalizedString = new System.Windows.Forms.CheckBox();
             this.labNumThreads = new System.Windows.Forms.Label();
             this.numThreads = new System.Windows.Forms.NumericUpDown();
@@ -68,7 +69,7 @@
             this.colSkipped = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colExceptions = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.txtLog = new System.Windows.Forms.TextBox();
-            this.chkDumpOnlyEdited = new System.Windows.Forms.CheckBox();
+            this.chkDumpYML = new System.Windows.Forms.CheckBox();
             this.pnlControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numThreads)).BeginInit();
             this.grpExistingFiles.SuspendLayout();
@@ -83,7 +84,7 @@
             this.btnRun.Image = global::WolvenKit.Properties.Resources.Output_16x;
             this.btnRun.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnRun.Location = new System.Drawing.Point(260, 633);
-            this.btnRun.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btnRun.Margin = new System.Windows.Forms.Padding(4);
             this.btnRun.Name = "btnRun";
             this.btnRun.Size = new System.Drawing.Size(560, 28);
             this.btnRun.TabIndex = 30;
@@ -98,7 +99,7 @@
             this.rtfDescription.Cursor = System.Windows.Forms.Cursors.Default;
             this.rtfDescription.Font = new System.Drawing.Font("Calibri", 9F);
             this.rtfDescription.Location = new System.Drawing.Point(16, 14);
-            this.rtfDescription.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.rtfDescription.Margin = new System.Windows.Forms.Padding(4);
             this.rtfDescription.Name = "rtfDescription";
             this.rtfDescription.ReadOnly = true;
             this.rtfDescription.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
@@ -109,6 +110,7 @@
             // 
             // pnlControls
             // 
+            this.pnlControls.Controls.Add(this.chkDumpYML);
             this.pnlControls.Controls.Add(this.chkDumpOnlyEdited);
             this.pnlControls.Controls.Add(this.chkLocalizedString);
             this.pnlControls.Controls.Add(this.labNumThreads);
@@ -130,10 +132,23 @@
             this.pnlControls.Controls.Add(this.txtPath);
             this.pnlControls.Controls.Add(this.grpRadioOutputMode);
             this.pnlControls.Location = new System.Drawing.Point(16, 236);
-            this.pnlControls.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.pnlControls.Margin = new System.Windows.Forms.Padding(4);
             this.pnlControls.Name = "pnlControls";
             this.pnlControls.Size = new System.Drawing.Size(987, 386);
             this.pnlControls.TabIndex = 21;
+            // 
+            // chkDumpOnlyEdited
+            // 
+            this.chkDumpOnlyEdited.AutoSize = true;
+            this.chkDumpOnlyEdited.Checked = true;
+            this.chkDumpOnlyEdited.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkDumpOnlyEdited.Location = new System.Drawing.Point(604, 156);
+            this.chkDumpOnlyEdited.Margin = new System.Windows.Forms.Padding(4);
+            this.chkDumpOnlyEdited.Name = "chkDumpOnlyEdited";
+            this.chkDumpOnlyEdited.Size = new System.Drawing.Size(178, 20);
+            this.chkDumpOnlyEdited.TabIndex = 38;
+            this.chkDumpOnlyEdited.Text = "Dump only edited values";
+            this.chkDumpOnlyEdited.UseVisualStyleBackColor = true;
             // 
             // chkLocalizedString
             // 
@@ -141,7 +156,7 @@
             this.chkLocalizedString.Checked = true;
             this.chkLocalizedString.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkLocalizedString.Location = new System.Drawing.Point(192, 282);
-            this.chkLocalizedString.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.chkLocalizedString.Margin = new System.Windows.Forms.Padding(4);
             this.chkLocalizedString.Name = "chkLocalizedString";
             this.chkLocalizedString.Size = new System.Drawing.Size(249, 20);
             this.chkLocalizedString.TabIndex = 15;
@@ -161,7 +176,7 @@
             // numThreads
             // 
             this.numThreads.Location = new System.Drawing.Point(541, 62);
-            this.numThreads.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.numThreads.Margin = new System.Windows.Forms.Padding(4);
             this.numThreads.Minimum = new decimal(new int[] {
             1,
             0,
@@ -183,7 +198,7 @@
             this.chkCreateFolders.Checked = true;
             this.chkCreateFolders.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCreateFolders.Location = new System.Drawing.Point(192, 156);
-            this.chkCreateFolders.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.chkCreateFolders.Margin = new System.Windows.Forms.Padding(4);
             this.chkCreateFolders.Name = "chkCreateFolders";
             this.chkCreateFolders.Size = new System.Drawing.Size(191, 20);
             this.chkCreateFolders.TabIndex = 10;
@@ -194,7 +209,7 @@
             // 
             this.chkDumpEmbedded.AutoSize = true;
             this.chkDumpEmbedded.Location = new System.Drawing.Point(192, 206);
-            this.chkDumpEmbedded.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.chkDumpEmbedded.Margin = new System.Windows.Forms.Padding(4);
             this.chkDumpEmbedded.Name = "chkDumpEmbedded";
             this.chkDumpEmbedded.Size = new System.Drawing.Size(147, 20);
             this.chkDumpEmbedded.TabIndex = 12;
@@ -206,9 +221,9 @@
             this.grpExistingFiles.Controls.Add(this.radExistingSkip);
             this.grpExistingFiles.Controls.Add(this.radExistingOverwrite);
             this.grpExistingFiles.Location = new System.Drawing.Point(192, 314);
-            this.grpExistingFiles.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grpExistingFiles.Margin = new System.Windows.Forms.Padding(4);
             this.grpExistingFiles.Name = "grpExistingFiles";
-            this.grpExistingFiles.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grpExistingFiles.Padding = new System.Windows.Forms.Padding(4);
             this.grpExistingFiles.Size = new System.Drawing.Size(189, 69);
             this.grpExistingFiles.TabIndex = 20;
             this.grpExistingFiles.TabStop = false;
@@ -217,7 +232,7 @@
             // 
             this.radExistingSkip.AutoSize = true;
             this.radExistingSkip.Location = new System.Drawing.Point(8, 41);
-            this.radExistingSkip.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.radExistingSkip.Margin = new System.Windows.Forms.Padding(4);
             this.radExistingSkip.Name = "radExistingSkip";
             this.radExistingSkip.Size = new System.Drawing.Size(131, 20);
             this.radExistingSkip.TabIndex = 22;
@@ -230,7 +245,7 @@
             this.radExistingOverwrite.AutoSize = true;
             this.radExistingOverwrite.Checked = true;
             this.radExistingOverwrite.Location = new System.Drawing.Point(8, 14);
-            this.radExistingOverwrite.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.radExistingOverwrite.Margin = new System.Windows.Forms.Padding(4);
             this.radExistingOverwrite.Name = "radExistingOverwrite";
             this.radExistingOverwrite.Size = new System.Drawing.Size(160, 20);
             this.radExistingOverwrite.TabIndex = 21;
@@ -242,7 +257,7 @@
             // 
             this.chkPrefixFileName.AutoSize = true;
             this.chkPrefixFileName.Location = new System.Drawing.Point(192, 182);
-            this.chkPrefixFileName.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.chkPrefixFileName.Margin = new System.Windows.Forms.Padding(4);
             this.chkPrefixFileName.Name = "chkPrefixFileName";
             this.chkPrefixFileName.Size = new System.Drawing.Size(202, 20);
             this.chkPrefixFileName.TabIndex = 11;
@@ -253,7 +268,7 @@
             // 
             this.chkDumpFCD.AutoSize = true;
             this.chkDumpFCD.Location = new System.Drawing.Point(192, 258);
-            this.chkDumpFCD.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.chkDumpFCD.Margin = new System.Windows.Forms.Padding(4);
             this.chkDumpFCD.Name = "chkDumpFCD";
             this.chkDumpFCD.Size = new System.Drawing.Size(173, 20);
             this.chkDumpFCD.TabIndex = 14;
@@ -266,7 +281,7 @@
             this.chkDumpSDB.Checked = true;
             this.chkDumpSDB.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkDumpSDB.Location = new System.Drawing.Point(192, 233);
-            this.chkDumpSDB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.chkDumpSDB.Margin = new System.Windows.Forms.Padding(4);
             this.chkDumpSDB.Name = "chkDumpSDB";
             this.chkDumpSDB.Size = new System.Drawing.Size(219, 20);
             this.chkDumpSDB.TabIndex = 13;
@@ -287,7 +302,7 @@
             // btnPickOutput
             // 
             this.btnPickOutput.Location = new System.Drawing.Point(804, 114);
-            this.btnPickOutput.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btnPickOutput.Margin = new System.Windows.Forms.Padding(4);
             this.btnPickOutput.Name = "btnPickOutput";
             this.btnPickOutput.Size = new System.Drawing.Size(100, 28);
             this.btnPickOutput.TabIndex = 8;
@@ -342,7 +357,7 @@
             // txtOutputDestination
             // 
             this.txtOutputDestination.Location = new System.Drawing.Point(192, 116);
-            this.txtOutputDestination.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtOutputDestination.Margin = new System.Windows.Forms.Padding(4);
             this.txtOutputDestination.Name = "txtOutputDestination";
             this.txtOutputDestination.Size = new System.Drawing.Size(603, 22);
             this.txtOutputDestination.TabIndex = 7;
@@ -351,7 +366,7 @@
             // btnChoosePath
             // 
             this.btnChoosePath.Location = new System.Drawing.Point(804, 14);
-            this.btnChoosePath.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btnChoosePath.Margin = new System.Windows.Forms.Padding(4);
             this.btnChoosePath.Name = "btnChoosePath";
             this.btnChoosePath.Size = new System.Drawing.Size(100, 25);
             this.btnChoosePath.TabIndex = 2;
@@ -362,7 +377,7 @@
             // txtPath
             // 
             this.txtPath.Location = new System.Drawing.Point(192, 14);
-            this.txtPath.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtPath.Margin = new System.Windows.Forms.Padding(4);
             this.txtPath.Name = "txtPath";
             this.txtPath.Size = new System.Drawing.Size(603, 22);
             this.txtPath.TabIndex = 1;
@@ -374,9 +389,9 @@
             this.grpRadioOutputMode.Controls.Add(this.radOutputModeSingleFile);
             this.grpRadioOutputMode.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.grpRadioOutputMode.Location = new System.Drawing.Point(192, 41);
-            this.grpRadioOutputMode.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grpRadioOutputMode.Margin = new System.Windows.Forms.Padding(4);
             this.grpRadioOutputMode.Name = "grpRadioOutputMode";
-            this.grpRadioOutputMode.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grpRadioOutputMode.Padding = new System.Windows.Forms.Padding(4);
             this.grpRadioOutputMode.Size = new System.Drawing.Size(189, 62);
             this.grpRadioOutputMode.TabIndex = 3;
             this.grpRadioOutputMode.TabStop = false;
@@ -386,7 +401,7 @@
             this.radOutputModeSeparateFiles.AutoSize = true;
             this.radOutputModeSeparateFiles.Checked = true;
             this.radOutputModeSeparateFiles.Location = new System.Drawing.Point(8, 14);
-            this.radOutputModeSeparateFiles.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.radOutputModeSeparateFiles.Margin = new System.Windows.Forms.Padding(4);
             this.radOutputModeSeparateFiles.Name = "radOutputModeSeparateFiles";
             this.radOutputModeSeparateFiles.Size = new System.Drawing.Size(161, 20);
             this.radOutputModeSeparateFiles.TabIndex = 4;
@@ -399,7 +414,7 @@
             // 
             this.radOutputModeSingleFile.AutoSize = true;
             this.radOutputModeSingleFile.Location = new System.Drawing.Point(8, 36);
-            this.radOutputModeSingleFile.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.radOutputModeSingleFile.Margin = new System.Windows.Forms.Padding(4);
             this.radOutputModeSingleFile.Name = "radOutputModeSingleFile";
             this.radOutputModeSingleFile.Size = new System.Drawing.Size(87, 20);
             this.radOutputModeSingleFile.TabIndex = 5;
@@ -451,7 +466,7 @@
             this.colSkipped,
             this.colExceptions});
             this.dataStatus.Location = new System.Drawing.Point(260, 674);
-            this.dataStatus.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.dataStatus.Margin = new System.Windows.Forms.Padding(4);
             this.dataStatus.MultiSelect = false;
             this.dataStatus.Name = "dataStatus";
             this.dataStatus.ReadOnly = true;
@@ -551,7 +566,7 @@
             // 
             this.txtLog.BackColor = System.Drawing.SystemColors.Window;
             this.txtLog.Location = new System.Drawing.Point(13, 752);
-            this.txtLog.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtLog.Margin = new System.Windows.Forms.Padding(4);
             this.txtLog.Multiline = true;
             this.txtLog.Name = "txtLog";
             this.txtLog.ReadOnly = true;
@@ -561,18 +576,18 @@
             this.txtLog.TabStop = false;
             this.txtLog.WordWrap = false;
             // 
-            // chkDumpOnlyEdited
+            // chkDumpYML
             // 
-            this.chkDumpOnlyEdited.AutoSize = true;
-            this.chkDumpOnlyEdited.Checked = true;
-            this.chkDumpOnlyEdited.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkDumpOnlyEdited.Location = new System.Drawing.Point(604, 156);
-            this.chkDumpOnlyEdited.Margin = new System.Windows.Forms.Padding(4);
-            this.chkDumpOnlyEdited.Name = "chkDumpOnlyEdited";
-            this.chkDumpOnlyEdited.Size = new System.Drawing.Size(178, 20);
-            this.chkDumpOnlyEdited.TabIndex = 38;
-            this.chkDumpOnlyEdited.Text = "Dump only edited values";
-            this.chkDumpOnlyEdited.UseVisualStyleBackColor = true;
+            this.chkDumpYML.AutoSize = true;
+            this.chkDumpYML.Checked = true;
+            this.chkDumpYML.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkDumpYML.Location = new System.Drawing.Point(604, 202);
+            this.chkDumpYML.Margin = new System.Windows.Forms.Padding(4);
+            this.chkDumpYML.Name = "chkDumpYML";
+            this.chkDumpYML.Size = new System.Drawing.Size(176, 20);
+            this.chkDumpYML.TabIndex = 39;
+            this.chkDumpYML.Text = "Dump YML (radish-style)";
+            this.chkDumpYML.UseVisualStyleBackColor = true;
             // 
             // frmCR2WtoText
             // 
@@ -586,7 +601,7 @@
             this.Controls.Add(this.btnRun);
             this.Controls.Add(this.pnlControls);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "frmCR2WtoText";
@@ -646,5 +661,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colExceptions;
         private System.Windows.Forms.CheckBox chkLocalizedString;
         private System.Windows.Forms.CheckBox chkDumpOnlyEdited;
+        private System.Windows.Forms.CheckBox chkDumpYML;
     }
 }

--- a/WolvenKit/Forms/frmCR2WtoText.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.cs
@@ -775,6 +775,7 @@ namespace WolvenKit.Forms
             mapInArray.Add(new List<string> { "CEntityTemplate", "bodyParts", "name" });
             mapInArray.Add(new List<string> { "CEntityTemplate", "slots", "name" });
             mapInArray.Add(new List<string> { "CEntityTemplate", "effects", "name" });
+            mapInArray.Add(new List<string> { "CByteArray", "streamingDataBuffer", "name" });
             // --- cutscenes
             mapInArray.Add(new List<string> { "CCutsceneTemplate", "effects", "name" });
             // --- entities
@@ -1075,7 +1076,10 @@ namespace WolvenKit.Forms
         }
         private void ProcessNodeYml_EngineTransform(IEditableVariable node, int cur_level, bool isArrayElement = false)
         {
-            WriterYml.Write((isArrayElement ? "- " : "") + prepareName(node.REDName) + ":", cur_level);
+            if (isArrayElement)
+                WriterYml.Write("- \".type\": " + node.REDType, cur_level);
+            else
+                WriterYml.Write(prepareName(node.REDName) + ":", cur_level);
             string x = "0.0", y = "0.0", z = "0.0", pitch = "0.0", yaw = "0.0", roll = "0.0", scale_x = "1.0", scale_y = "1.0", scale_z = "1.0";
             List<IEditableVariable> children = node.GetEditableVariables();
             
@@ -1139,7 +1143,7 @@ namespace WolvenKit.Forms
                         break;
                 }
             }
-            WriterYml.Write((isArrayElement ? "- " : "") + prepareName(node.REDName) + ": [ " + X + ", " + Y + ", " + Z + ", " + W + " ]", cur_level);
+            WriterYml.Write((isArrayElement ? "- " : (prepareName(node.REDName) + ": ")) + "[ " + X + ", " + Y + ", " + Z + ", " + W + " ]", cur_level);
         }
         private void ProcessNodeYml_EulerAngles(IEditableVariable node, int cur_level, bool isArrayElement = false)
         {
@@ -1161,7 +1165,7 @@ namespace WolvenKit.Forms
                         break;
                 }
             }
-            WriterYml.Write((isArrayElement ? "- " : "") + prepareName(node.REDName) + ": [ " + pitch + ", " + yaw + ", " + roll + " ]", cur_level);
+            WriterYml.Write((isArrayElement ? "- " : (prepareName(node.REDName) + ": ")) + "[ " + pitch + ", " + yaw + ", " + roll + " ]", cur_level);
         }
         private void ProcessNodeYml_Color(IEditableVariable node, int cur_level, bool isArrayElement = false)
         {
@@ -1186,7 +1190,7 @@ namespace WolvenKit.Forms
                         break;
                 }
             }
-            WriterYml.Write((isArrayElement ? "- " : "") + prepareName(node.REDName) + ": [ " + Red + ", " + Green + ", " + Blue + ((Alpha == "-1.0") ? "" : (", " + Alpha)) + " ]", cur_level);
+            WriterYml.Write((isArrayElement ? "- " : (prepareName(node.REDName) + ": ")) + "[ " + Red + ", " + Green + ", " + Blue + ((Alpha == "-1.0") ? "" : (", " + Alpha)) + " ]", cur_level);
         }
         private void ProcessNodeYml_cookedEffects(IEditableVariable node, int cur_level, bool isArrayElement = false)
         {
@@ -1331,26 +1335,26 @@ namespace WolvenKit.Forms
 
         private void ProcessNodeYml(IEditableVariable node, int level, bool isArrayElement = false, string useNameVar = "")
         {
-            //Console.WriteLine(new String(' ', level) + "> node: " + node.REDName + ", type: " + node.REDType + ", value: " + node.REDValue);
+            Console.WriteLine(new String(' ', level) + "> node: " + node.REDName + ", type: " + node.REDType + ", value: " + node.REDValue);
             // special cases for rmemr encoder
             if (node.REDType == "EngineTransform")
             {
-                ProcessNodeYml_EngineTransform(node, level);
+                ProcessNodeYml_EngineTransform(node, level, isArrayElement);
                 return;
             }
             if (node.REDType == "Vector" || node.REDType == "SVector4D")
             {
-                ProcessNodeYml_Vector(node, level);
+                ProcessNodeYml_Vector(node, level, isArrayElement);
                 return;
             }
             if (node.REDType == "EulerAngles")
             {
-                ProcessNodeYml_EulerAngles(node, level);
+                ProcessNodeYml_EulerAngles(node, level, isArrayElement);
                 return;
             }
             if (node.REDType == "Color")
             {
-                ProcessNodeYml_Color(node, level);
+                ProcessNodeYml_Color(node, level, isArrayElement);
                 return;
             }
             if (node.REDName == "cookedEffects")
@@ -1392,6 +1396,8 @@ namespace WolvenKit.Forms
             string mapNameVar = getSpecialYmlMapNameVar(node);
             if (useNameVar == "")
                 useNameVar = mapNameVar;
+
+            Console.WriteLine(new String(' ', level) + "> nodeExtra: Childs: " + children.Count());
 
             if (node.REDName == "AttachmentsChild" && children.Count() == 0)
                 return;


### PR DESCRIPTION
# Add support for YML radish-styled cr2w dumps

<PULL REQUEST TITLE>

Implemented:
- support for YML radish-styled cr2w dumps
- support for dumping only edited values

Fixes:
- CR2WToText: fix dumping data buffers
