### PR TITLE
CR2W Serialization fixes

### DIFF
--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/CXml.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/CXml.cs
@@ -52,9 +52,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case XDocument document:
                     Data = document;
+					SetIsSerialized();
                     break;
                 case CXml cvar:
-                    this.Data = cvar.Data;
+                    Data = cvar.Data;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/CXml.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/CXml.cs
@@ -38,6 +38,7 @@ namespace WolvenKit.CR2W.Types
         {
             var len = file.ReadInt32();
             backingfield = file.ReadBytes(len);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/CurveInfo.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/CurveInfo.cs
@@ -60,6 +60,7 @@ namespace WolvenKit.CR2W.Types
             pieces.Read(file, size, count);
 
             
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/CurvePiece.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/CurvePiece.cs
@@ -58,6 +58,7 @@ namespace WolvenKit.CR2W.Types
             }
 
             values.Read(file, size, valueCount.val);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SBlockData.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SBlockData.cs
@@ -104,6 +104,7 @@ namespace WolvenKit.CR2W.Types
             {
                 throw new InvalidParsingException("read too far");
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SBlockDataObjects/SBlockDataDecal.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SBlockDataObjects/SBlockDataDecal.cs
@@ -45,6 +45,7 @@ namespace WolvenKit.CR2W.Types
             {
                 throw new InvalidParsingException("read too far");
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SBlockDataObjects/SBlockDataMeshObject.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SBlockDataObjects/SBlockDataMeshObject.cs
@@ -43,6 +43,7 @@ namespace WolvenKit.CR2W.Types
             {
                 throw new InvalidParsingException("read too far");
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SEntityBufferType1.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SEntityBufferType1.cs
@@ -43,6 +43,7 @@ namespace WolvenKit.CR2W.Types.Utils
                 Guid.Read(file, 16);
                 Buffer.Read(file, size);
             }
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SEntityBufferType2.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SEntityBufferType2.cs
@@ -35,6 +35,7 @@ namespace WolvenKit.CR2W.Types
             sizeofdata.Read(file, 4);
             componentName.Read(file, 2);
             variables.Read(file, size);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SMeshBlock5.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SMeshBlock5.cs
@@ -32,6 +32,7 @@ namespace WolvenKit.CR2W.Types
                 throw new NotImplementedException();
 
             unk1.Read(file, (uint)bytesize.val - 2);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SParticleEmitterModuleData.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SParticleEmitterModuleData.cs
@@ -173,6 +173,7 @@ namespace WolvenKit.CR2W.Types
                 CVariable variable = fields[i];
                 variable.Read(file, size);
             }
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SParticleEmitterModuleData.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SParticleEmitterModuleData.cs
@@ -193,6 +193,7 @@ namespace WolvenKit.CR2W.Types
             if (val is SParticleEmitterModuleData)
             {
                 fields = (val as SParticleEmitterModuleData).fields;
+				SetIsSerialized();
             }
             return this;
         }

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SVector3D.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SVector3D.cs
@@ -82,6 +82,7 @@ namespace WolvenKit.CR2W.Types
                 this.X = v.X;
                 this.Y = v.Y;
                 this.Z = v.Z;
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SVector3D.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/Complex/SVector3D.cs
@@ -66,6 +66,7 @@ namespace WolvenKit.CR2W.Types
             X.Read(file, size);
             Y.Read(file, size);
             Z.Read(file, size);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/SMipData.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/SMipData.cs
@@ -31,6 +31,7 @@ namespace WolvenKit.CR2W.Types
             // if is uncooked
             if (this.REDFlags == 0)
                 Mip.Read(file, 0);
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/SVector2D.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferStructs/SVector2D.cs
@@ -24,6 +24,7 @@ namespace WolvenKit.CR2W.Types
             {
                 this.x = v.x;
                 this.y = v.y;
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferedClasses.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferedClasses.cs
@@ -183,6 +183,7 @@ namespace WolvenKit.CR2W.Types
             if (val is CXml)
             {
                 Ragdolldata = (CXml)val;
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/BufferedTypes/BufferedClasses.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/BufferedClasses.cs
@@ -208,6 +208,7 @@ namespace WolvenKit.CR2W.Types
                 return;
             Unk1 = new CUInt32(cr2w, this, nameof(Unk1)) { IsSerialized = true };
             Unk1.Read(file, size);
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CBitmapTexture.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CBitmapTexture.cs
@@ -73,6 +73,7 @@ namespace WolvenKit.CR2W.Types
             unk1.Read(file, 2);
             unk2.Read(file, 2);
             Residentmip.Read(file, ResidentmipSize.val);
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CCubeTexture.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CCubeTexture.cs
@@ -38,6 +38,7 @@ namespace WolvenKit.CR2W.Types
 
             
             Rawfile.Read(file, Filesize.val);
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CEntity.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CEntity.cs
@@ -112,6 +112,7 @@ namespace WolvenKit.CR2W.Types
             }
             #endregion
 
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CFXTrackItem.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CFXTrackItem.cs
@@ -45,6 +45,7 @@ namespace WolvenKit.CR2W.Types
             {
 
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CFont.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CFont.cs
@@ -87,6 +87,7 @@ namespace WolvenKit.CR2W.Types
 
                 Glyphs.AddVariable(glyph);
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CGenericGrassMask.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CGenericGrassMask.cs
@@ -34,6 +34,7 @@ namespace WolvenKit.CR2W.Types
             if (MaskRes == null) return;
             var res = MaskRes.val;
             grassmask.Bytes = file.ReadBytes((int)(res * res >> 3));
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CLayerInfo.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CLayerInfo.cs
@@ -34,6 +34,7 @@ namespace WolvenKit.CR2W.Types
                 ParentGroup.ChunkHandle = true;
                 ParentGroup.Read(file, 4);
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CPhysicalCollision.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CPhysicalCollision.cs
@@ -32,6 +32,7 @@ namespace WolvenKit.CR2W.Types
             var endpos = file.BaseStream.Position;
 
             Data.Read(file, (uint)(size - (endpos - startpos)));
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CQuestScriptBlock.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CQuestScriptBlock.cs
@@ -37,6 +37,7 @@ namespace WolvenKit.CR2W.Types
 
                 BufferParameters.AddVariableWithName(cVariant);
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CSectorData.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CSectorData.cs
@@ -66,6 +66,7 @@ namespace WolvenKit.CR2W.Types
                 blockdata.Read(file, (uint)len);
                 BlockData.AddVariable(blockdata);
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CSkeleton.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CSkeleton.cs
@@ -31,6 +31,7 @@ namespace WolvenKit.CR2W.Types
 
             rigdata.Read(file, (uint)bonecount * 48, bonecount);
             
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CStorySceneScript.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CStorySceneScript.cs
@@ -36,6 +36,7 @@ namespace WolvenKit.CR2W.Types
 
                 BufferParameters.AddVariableWithName(cVariant);
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CSwfTexture.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CSwfTexture.cs
@@ -29,6 +29,7 @@ namespace WolvenKit.CR2W.Types
             //var textureSize = Convert.ToInt32( size - (file.BaseStream.Position - pos) );
 
             //swfTexture.Read(file, (uint)textureSize);
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CTerrainTile.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CTerrainTile.cs
@@ -28,6 +28,7 @@ namespace WolvenKit.CR2W.Types
             base.Read(file, size);
 
             var maxres = file.ReadInt32();
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CTextureArray.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CTextureArray.cs
@@ -42,6 +42,7 @@ namespace WolvenKit.CR2W.Types
             base.Read(file, size);
 
             rawfile.Read(file, filesize.val);
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/CWayPointsCollection.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/CWayPointsCollection.cs
@@ -55,6 +55,7 @@ namespace WolvenKit.CR2W.Types
                     throw new InvalidParsingException("Did not read buffer to the end.");
             }
 
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/BufferedTypes/Complex/SAppearanceAttachment.cs
+++ b/WolvenKit.CR2W/Types/BufferedTypes/Complex/SAppearanceAttachment.cs
@@ -51,6 +51,7 @@ namespace WolvenKit.CR2W.Types
             {
                 throw new InvalidParsingException($"Error in parsing SAppearanceAttachment: Data Variable. Bytes read: {bytesread} out of {bytecount}.");
             }
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CArray.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CArray.cs
@@ -24,6 +24,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             base.Read(file, size, (int)file.ReadUInt32());
+            //SetIsSerialized() in base
         }
 
 

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CArrayBase.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CArrayBase.cs
@@ -64,6 +64,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             throw new NotImplementedException();
+            SetIsSerialized();
         }
 
         protected void Read(BinaryReader file, uint size, int elementcount)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CArrayBase.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CArrayBase.cs
@@ -98,6 +98,7 @@ namespace WolvenKit.CR2W.Types
             if (val is CArrayBase<T> cvar)
             {
                 this.Elements = cvar.Elements;
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CBufferBase.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CBufferBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -94,6 +94,7 @@ namespace WolvenKit.CR2W.Types
                 variable.SetREDName(elements.Count.ToString());
                 tvar.IsSerialized = true;
                 elements.Add(tvar);
+                SetIsSerialized();
             }
         }
         public void AddVariableWithName(CVariable variable)
@@ -102,6 +103,7 @@ namespace WolvenKit.CR2W.Types
             {
                 tvar.IsSerialized = true;
                 elements.Add(tvar);
+                SetIsSerialized();
             }
         }
         public override bool CanRemoveVariable(IEditableVariable child)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CBufferBase.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CBufferBase.cs
@@ -53,6 +53,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             throw new NotImplementedException();
+            SetIsSerialized();
         }
 
         public void Read(BinaryReader file, uint size, int elementcount)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CBufferBit6.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CBufferBit6.cs
@@ -17,6 +17,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             base.Read(file, size, (int)file.ReadBit6());
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CBufferUInt32.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CBufferUInt32.cs
@@ -21,6 +21,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             base.Read(file, size, (int)file.ReadUInt32());
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CBufferUint16.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CBufferUint16.cs
@@ -25,6 +25,7 @@ namespace WolvenKit.CR2W.Types
             count.Read(file, size);
 
             base.Read(file, size, (int)count.val);
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CBufferVLQInt32.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CBufferVLQInt32.cs
@@ -19,6 +19,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             base.Read(file, size, (int)file.ReadVLQInt32());
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CCompressedBuffer.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CCompressedBuffer.cs
@@ -37,6 +37,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             throw new NotImplementedException();
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Generic/Arrays/CPaddedBuffer.cs
+++ b/WolvenKit.CR2W/Types/Generic/Arrays/CPaddedBuffer.cs
@@ -30,6 +30,7 @@ namespace WolvenKit.CR2W.Types
             base.Read(file, size, count.val);
 
             padding.Read(file, 4);
+            //SetIsSerialized() in base
         }
 
         public override List<IEditableVariable> GetEditableVariables()

--- a/WolvenKit.CR2W/Types/Generic/CHandle.cs
+++ b/WolvenKit.CR2W/Types/Generic/CHandle.cs
@@ -68,6 +68,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             SetValueInternal(file.ReadInt32());
+            SetIsSerialized();
         }
 
         private void SetValueInternal(int val)

--- a/WolvenKit.CR2W/Types/Generic/CHandle.cs
+++ b/WolvenKit.CR2W/Types/Generic/CHandle.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
@@ -130,6 +130,7 @@ namespace WolvenKit.CR2W.Types
             {
                 case int o:
                     SetValueInternal(o);
+					SetIsSerialized();
                     break;
                 case IHandleAccessor cvar:
                     this.ChunkHandle = cvar.ChunkHandle;
@@ -138,6 +139,7 @@ namespace WolvenKit.CR2W.Types
                     this.Flags = cvar.Flags;
 
                     this.Reference = cvar.Reference;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Generic/CPtr.cs
+++ b/WolvenKit.CR2W/Types/Generic/CPtr.cs
@@ -51,6 +51,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             SetValueInternal(file.ReadInt32());
+            SetIsSerialized();
         }
 
         private void SetValueInternal(int val)
@@ -104,10 +105,12 @@ namespace WolvenKit.CR2W.Types
             switch (val)
             {
                 case CR2WExportWrapper wrapper:
+                    //IsSerialized = true;
                     Reference = wrapper;
 					SetIsSerialized();
                     break;
                 case IPtrAccessor cval:
+                    //IsSerialized = true;
                     Reference = cval.Reference;
 					SetIsSerialized();
                     break;

--- a/WolvenKit.CR2W/Types/Generic/CPtr.cs
+++ b/WolvenKit.CR2W/Types/Generic/CPtr.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -105,9 +105,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case CR2WExportWrapper wrapper:
                     Reference = wrapper;
+					SetIsSerialized();
                     break;
                 case IPtrAccessor cval:
                     Reference = cval.Reference;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Generic/CSoft.cs
+++ b/WolvenKit.CR2W/Types/Generic/CSoft.cs
@@ -79,11 +79,13 @@ namespace WolvenKit.CR2W.Types
             {
                 case ushort o:
                     this.SetValueInternal(o);
+					SetIsSerialized();
                     break;
                 case ISoftAccessor cvar:
                     this.DepotPath = cvar.DepotPath;
                     this.ClassName = cvar.ClassName;
                     this.Flags = cvar.Flags;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Generic/CSoft.cs
+++ b/WolvenKit.CR2W/Types/Generic/CSoft.cs
@@ -37,6 +37,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             SetValueInternal(file.ReadUInt16());
+            SetIsSerialized();
         }
         
         private void SetValueInternal(ushort value)

--- a/WolvenKit.CR2W/Types/Primitive/CColor.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CColor.cs
@@ -33,6 +33,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             base.Read(file, size);
+            //SetIsSerialized() in base
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/CColor.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CColor.cs
@@ -57,9 +57,12 @@ namespace WolvenKit.CR2W.Types
             if (val is Color)
             {
                 Color = (Color)val;
+				SetIsSerialized();
             }
-            else if (val is CColor cvar)
+            else if (val is CColor cvar) {
                 Color = cvar.Color;
+				SetIsSerialized();
+			}
 
             return this;
         }

--- a/WolvenKit.CR2W/Types/Primitive/CColorShift.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CColorShift.cs
@@ -34,9 +34,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case Color o:
                     Color = HslColor.FromRgb(o);
+					SetIsSerialized();
                     break;
                 case CColorShift cvar:
                     Color = cvar.Color;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Primitive/CName.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CName.cs
@@ -51,9 +51,12 @@ namespace WolvenKit.CR2W.Types
             if (val is string)
             {
                 Value = (string)val;
+				SetIsSerialized();
             }
-            else if (val is CName cval)
+            else if (val is CName cval) {
                 Value = cval.Value;
+				SetIsSerialized();
+			}
 
             return this;
         }

--- a/WolvenKit.CR2W/Types/Primitive/CName.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CName.cs
@@ -30,6 +30,7 @@ namespace WolvenKit.CR2W.Types
         {
             var idx = file.ReadUInt16();
             Value = cr2w.names[idx].Str;
+            SetIsSerialized();
         }
 
         /// <summary>

--- a/WolvenKit.CR2W/Types/Primitive/CVLQArray.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CVLQArray.cs
@@ -69,6 +69,8 @@ namespace WolvenKit.CR2W.Types
 
                 AddVariable(var);
             }
+			if (array.Count > 0)
+				SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/CVLQArray.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CVLQArray.cs
@@ -91,6 +91,7 @@ namespace WolvenKit.CR2W.Types
                 {
                     AddVariable(item);
                 }
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/Primitive/CVariant.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CVariant.cs
@@ -74,6 +74,7 @@ namespace WolvenKit.CR2W.Types
                     Parent = this.ParentVar as CVariable
                 };
                 this.Variant = cvar.Variant.Copy(context);
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/Primitive/CVariant.cs
+++ b/WolvenKit.CR2W/Types/Primitive/CVariant.cs
@@ -35,6 +35,7 @@ namespace WolvenKit.CR2W.Types
             {
                 // do nothing I guess?
             }
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/EntityHandle.cs
+++ b/WolvenKit.CR2W/Types/Primitive/EntityHandle.cs
@@ -35,6 +35,7 @@ namespace WolvenKit.CR2W.Types
                 unk1.Read(file, size - 18);
             }
 
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/IdHandle.cs
+++ b/WolvenKit.CR2W/Types/Primitive/IdHandle.cs
@@ -26,6 +26,7 @@ namespace WolvenKit.CR2W.Types
         {
             handlename.Read(file, 2);
             handle.Read(file, 2);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/IdTag.cs
+++ b/WolvenKit.CR2W/Types/Primitive/IdTag.cs
@@ -47,6 +47,7 @@ namespace WolvenKit.CR2W.Types
         {
             _type = file.ReadByte();
             _guid = file.ReadBytes(16);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/IdTag.cs
+++ b/WolvenKit.CR2W/Types/Primitive/IdTag.cs
@@ -68,15 +68,18 @@ namespace WolvenKit.CR2W.Types
             if(val is byte[])
             {
                 _guid = (byte[])val;
+				SetIsSerialized();
             }
             else if(val is byte)
             {
                 _type = (byte)val;
+				SetIsSerialized();
             }
             else if (val is IdTag cvar)
             {
                 _guid = cvar._guid;
                 _type = cvar._type;
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/Primitive/LocalizedString.cs
+++ b/WolvenKit.CR2W/Types/Primitive/LocalizedString.cs
@@ -35,6 +35,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             val = file.ReadUInt32();
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/LocalizedString.cs
+++ b/WolvenKit.CR2W/Types/Primitive/LocalizedString.cs
@@ -47,14 +47,17 @@ namespace WolvenKit.CR2W.Types
             if (val is uint)
             {
                 this.val = (uint)val;
+				SetIsSerialized();
             }
             else if (val is int)
             {
                 this.val = (uint)(int)val;
+				SetIsSerialized();
             }
             else if (val is LocalizedString cvar)
             {
                 this.val = cvar.val;
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CByteArray.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CByteArray.cs
@@ -42,9 +42,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case byte[] bytes:
                     Bytes = bytes;
+					SetIsSerialized();
                     break;
                 case CByteArray cvar:
                     this.Bytes = cvar.Bytes;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CByteArray.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CByteArray.cs
@@ -21,6 +21,7 @@ namespace WolvenKit.CR2W.Types
         {
             var arraysize = file.ReadUInt32();
             Bytes = file.ReadBytes((int) arraysize);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CByteArray2.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CByteArray2.cs
@@ -21,6 +21,7 @@ namespace WolvenKit.CR2W.Types
         {
             var arraysize = file.ReadUInt32();
             Bytes = file.ReadBytes((int) arraysize - 4);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CByteArray2.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CByteArray2.cs
@@ -43,9 +43,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case byte[] bytes:
                     Bytes = bytes;
+					SetIsSerialized();
                     break;
                 case CByteArray2 cvar:
                     this.Bytes = cvar.Bytes;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CBytes.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CBytes.cs
@@ -19,6 +19,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             Bytes = file.ReadBytes((int) size);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CBytes.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CBytes.cs
@@ -39,9 +39,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case byte[] bytes:
                     Bytes = bytes;
+					SetIsSerialized();
                     break;
                 case CBytes cvar:
                     this.Bytes = cvar.Bytes;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CDateTime.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CDateTime.cs
@@ -193,6 +193,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             TryParse(this, file.ReadUInt64());
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CEnum.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CEnum.cs
@@ -102,6 +102,7 @@ namespace WolvenKit.CR2W.Types
             }
 
             SetValue(strings);
+            SetIsSerialized();
         }
 
         /// <summary>

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CEnum.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CEnum.cs
@@ -170,6 +170,7 @@ namespace WolvenKit.CR2W.Types
                 T en = (T)Enum.Parse(WrappedEnum.GetType(), finalvalue);
                 WrappedEnum = en;
             }
+			SetIsSerialized();
 
             return this;
         }

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CFloat.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CFloat.cs
@@ -20,6 +20,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             val = file.ReadSingle();
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CFloat.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CFloat.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Runtime.Serialization;
 using WolvenKit.CR2W.Reflection;
 
@@ -33,9 +33,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case float o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case CFloat cvar:
                     this.val = cvar.val;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CGUID.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CGUID.cs
@@ -35,6 +35,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             guid = file.ReadBytes(16);
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CGUID.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CGUID.cs
@@ -48,9 +48,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case byte[] o:
                     guid = o;
+					SetIsSerialized();
                     break;
                 case CGUID cvar:
                     this.guid = cvar.guid;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CString.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CString.cs
@@ -24,6 +24,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             val = file.ReadLengthPrefixedString();
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CString.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/CString.cs
@@ -37,9 +37,11 @@ namespace WolvenKit.CR2W.Types
             {
                 case string s:
                     this.val = s;
+					SetIsSerialized();
                     break;
                 case CString cvar:
                     this.val = cvar.val;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/IntegerTypes.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/IntegerTypes.cs
@@ -26,6 +26,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             val = file.ReadUInt64();
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/IntegerTypes.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/IntegerTypes.cs
@@ -39,12 +39,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case ulong o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = ulong.Parse(s);
+					SetIsSerialized();
                     break;
                 case CUInt64 v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 
@@ -210,12 +213,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case byte o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = byte.Parse(s);
+					SetIsSerialized();
                     break;
                 case CUInt8 v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 
@@ -266,12 +272,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case long o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = long.Parse(s);
+					SetIsSerialized();
                     break;
                 case CInt64 v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 
@@ -324,12 +333,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case int o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = int.Parse(s);
+					SetIsSerialized();
                     break;
                 case CInt32 v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 
@@ -380,12 +392,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case short o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = short.Parse(s);
+					SetIsSerialized();
                     break;
                 case CInt16 v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 
@@ -436,12 +451,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case sbyte o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = sbyte.Parse(s);
+					SetIsSerialized();
                     break;
                 case CInt8 v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 
@@ -492,12 +510,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case sbyte o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = sbyte.Parse(s);
+					SetIsSerialized();
                     break;
                 case CDynamicInt v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 
@@ -555,12 +576,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case sbyte o:
                     this.val = o;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = sbyte.Parse(s);
+					SetIsSerialized();
                     break;
                 case CVLQInt32 v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 
@@ -620,12 +644,15 @@ namespace WolvenKit.CR2W.Types
             {
                 case bool b:
                     this.val = b;
+					SetIsSerialized();
                     break;
                 case string s:
                     this.val = bool.Parse(s);
+					SetIsSerialized();
                     break;
                 case CBool v:
                     this.val = v.val;
+					SetIsSerialized();
                     break;
             }
 

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/StringAnsi.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/StringAnsi.cs
@@ -32,10 +32,12 @@ namespace WolvenKit.CR2W.Types
             if (val is string)
             {
                 this.val = (string) val;
+				SetIsSerialized();
             }
             else if (val is StringAnsi cvar)
             {
                 this.val = cvar.val;
+				SetIsSerialized();
             }
             return this;
         }

--- a/WolvenKit.CR2W/Types/Primitive/NetPrimitive/StringAnsi.cs
+++ b/WolvenKit.CR2W/Types/Primitive/NetPrimitive/StringAnsi.cs
@@ -20,6 +20,7 @@ namespace WolvenKit.CR2W.Types
         public override void Read(BinaryReader file, uint size)
         {
             val = file.ReadLengthPrefixedStringNullTerminated();
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Structs/Complex/EngineQsTranform.cs
+++ b/WolvenKit.CR2W/Types/Structs/Complex/EngineQsTranform.cs
@@ -68,6 +68,7 @@ namespace WolvenKit.CR2W.Types
                 Scale_y.Read(file, 4);
                 Scale_z.Read(file, 4);
             }
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Structs/Complex/EngineTransform.cs
+++ b/WolvenKit.CR2W/Types/Structs/Complex/EngineTransform.cs
@@ -62,6 +62,7 @@ namespace WolvenKit.CR2W.Types
                 Scale_y.Read(file, 4);
                 Scale_z.Read(file, 4);
             }
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Structs/Complex/TagList.cs
+++ b/WolvenKit.CR2W/Types/Structs/Complex/TagList.cs
@@ -27,6 +27,8 @@ namespace WolvenKit.CR2W.Types
                 var.Read(file, 0);
                 AddVariable(var);
             }
+			if (count > 0)
+				SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Utils/CMatrix3x3.cs
+++ b/WolvenKit.CR2W/Types/Utils/CMatrix3x3.cs
@@ -47,6 +47,7 @@ namespace WolvenKit.CR2W.Types
             {
                 variable.Read(file, size);
             }
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Utils/CMatrix4x4.cs
+++ b/WolvenKit.CR2W/Types/Utils/CMatrix4x4.cs
@@ -54,6 +54,7 @@ namespace WolvenKit.CR2W.Types
             {
                 variable.Read(file, size);
             }
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Utils/CMatrix4x4.cs
+++ b/WolvenKit.CR2W/Types/Utils/CMatrix4x4.cs
@@ -78,8 +78,10 @@ namespace WolvenKit.CR2W.Types
 
         public override CVariable SetValue(object val)
         {
-            if (val is CMatrix4x4 v)
+            if (val is CMatrix4x4 v) {
                 this.fields = v.fields;
+				SetIsSerialized();
+			}
 
             return this;
         }

--- a/WolvenKit.CR2W/Types/Utils/CVariable.cs
+++ b/WolvenKit.CR2W/Types/Utils/CVariable.cs
@@ -1,4 +1,4 @@
-﻿using DotNetHelper.FastMember.Extension.Extension;
+using DotNetHelper.FastMember.Extension.Extension;
 using FastMember;
 using System;
 using System.CodeDom;
@@ -56,7 +56,7 @@ namespace WolvenKit.CR2W.Types
         /// Shows if the CVariable is to be serialized
         /// important because cr2w files only serialize initialized variables
         /// and some types are not null by default
-        /// Is set upon read
+        /// Is set upon Read(..) and SetValue(..)
         /// Must also be set when a variable is edited in the editor
         /// </summary>
         public bool IsSerialized { get; set; }
@@ -324,7 +324,6 @@ namespace WolvenKit.CR2W.Types
                         break;
 
                     cvar.IsSerialized = true;
-
 #if DEBUG
                     dbg_varnames.Add($"[{cvar.REDType}] {cvar.REDName}");
 #endif
@@ -590,6 +589,7 @@ namespace WolvenKit.CR2W.Types
                     if (item is CVariable citem)
                         this.TrySettingFastMemberAccessor(citem);
                 }
+				SetIsSerialized();
             }
 
             return this;

--- a/WolvenKit.CR2W/Types/Utils/CVariantSizeNameType.cs
+++ b/WolvenKit.CR2W/Types/Utils/CVariantSizeNameType.cs
@@ -49,6 +49,7 @@ namespace WolvenKit.CR2W.Types
             }
 
             Variant = parsedvar;
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Utils/CVariantSizeType.cs
+++ b/WolvenKit.CR2W/Types/Utils/CVariantSizeType.cs
@@ -43,6 +43,7 @@ namespace WolvenKit.CR2W.Types
             }
 
             Variant = parsedvar;
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)

--- a/WolvenKit.CR2W/Types/Utils/CVariantSizeTypeName.cs
+++ b/WolvenKit.CR2W/Types/Utils/CVariantSizeTypeName.cs
@@ -48,6 +48,7 @@ namespace WolvenKit.CR2W.Types
             }
 
             Variant = parsedvar;
+            SetIsSerialized();
         }
 
         public override void Write(BinaryWriter file)


### PR DESCRIPTION
# CR2W Serialization fixes

<PULL REQUEST TITLE>

- Makes every _CVariable_ class `SetIsSerialized()` on _Read(..)_ and _SetValue(..)_, since these functions assume that CVar contains some data and is not "default" anymore (for SetValue it is checked if new data was really set)
- It fixes bug when some structures like `tags` (_CBufferVLQInt32:CName_) in _CEntity_ and `moduleData` (_SParticleEmitterModuleData_) in _CParticleEmitter_ were not marked as "edited" despite having edited children variables (what led to missing these vars in "Show only edited vars" mode in Variable Editor; and in "Dump only edited values" mode in CR2WToText/CR2WToYML)

TODO?:
- Handle special cases for classes with AddSomeVar() functions, if thery are created and edited from a code.

<Additional notes>
