### PR TITLE
write the internal buffers when creating a new cr2w from json

### DIFF
--- a/WolvenKit.CR2W/CR2W/CR2WFile.cs
+++ b/WolvenKit.CR2W/CR2W/CR2WFile.cs
@@ -66,7 +66,7 @@ namespace WolvenKit.CR2W
 
         // misc
         private uint headerOffset = 0;
-        private bool m_hasInternalBuffer;
+        public bool m_hasInternalBuffer;
         //private Stream m_stream; //handle this better?
         // private string m_filePath;
 

--- a/WolvenKit.CR2W/JSON/CR2WJsonTool.cs
+++ b/WolvenKit.CR2W/JSON/CR2WJsonTool.cs
@@ -126,6 +126,14 @@ namespace WolvenKit.CR2W.JSON
                 return false;
             }
 
+            for (int i = 0; i < cr2w.buffers.Count; i++)
+            {
+                if (cr2w.buffers[i].Data != null)
+                {
+                    cr2w.m_hasInternalBuffer = true;
+                    break;
+                }
+            }
             WriteCR2W(cr2w, cr2wPath);
             return true;
         }


### PR DESCRIPTION
Fixed:
- internal buffers were not being written

