### PR TITLE
Fixed issues regarding to searching and packing encoded w3strings.

### DIFF
--- a/WolvenKit.App/ViewModels/MainViewModel.cs
+++ b/WolvenKit.App/ViewModels/MainViewModel.cs
@@ -845,9 +845,9 @@ namespace WolvenKit.App.ViewModels
                     var files = Directory.GetFiles((ActiveMod.ProjectDirectory + "\\strings")).Where(s => Path.GetExtension(s) == ".w3strings").ToList();
 
                     if (packsettings.Strings.Item1)
-                        files.ForEach(x => File.Copy(x, Path.Combine(ActiveMod.PackedDlcDirectory, Path.GetFileName(x))));
-                    if (packsettings.Strings.Item2)
                         files.ForEach(x => File.Copy(x, Path.Combine(ActiveMod.PackedModDirectory, Path.GetFileName(x))));
+                    if (packsettings.Strings.Item2)
+                        files.ForEach(x => File.Copy(x, Path.Combine(ActiveMod.PackedDlcDirectory, Path.GetFileName(x))));
                 }
                 #endregion
                 MainController.Get().StatusProgress = 90;

--- a/WolvenKit/Forms/frmStringsGuiImporter.cs
+++ b/WolvenKit/Forms/frmStringsGuiImporter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -182,14 +182,20 @@ namespace WolvenKit
             if (matchCaseSearch)
                 foreach (var str in strings)
                 {
-                    if (str[2].Contains(textBoxSearch.Text))
-                        results.Add(str);
+                    if (str[2] != null)
+                    {
+                        if (str[2].Contains(textBoxSearch.Text))
+                            results.Add(str);
+                    }
                 }
             else
                 foreach (var str in strings)
                 {
-                    if (str[2].ToUpper().Contains(textBoxSearch.Text.ToUpper()))
-                        results.Add(str);
+                    if (str[2] != null)
+                    {
+                        if (str[2].ToUpper().Contains(textBoxSearch.Text.ToUpper()))
+                            results.Add(str);
+                    }
                 }
             FillListView(results.ToList());
         }


### PR DESCRIPTION
# Pull request template

<PULL REQUEST TITLE>

Implemented:
- Add extra null checks when searching through the text properties of w3strings data when searching.
- Generated w3strings are now copied to the correct directory paths.

Issues that were fixed:
- #32
- #33


<Additional notes>

At packing settings: Instead of using 'Item1' and 'Item2' to name the checkbox options, we should maybe use something like 'ModCheck' and 'DlcCheck' for easier debugging of these items.
