### PR TITLE
soundcache packing fix

### DIFF
--- a/WolvenKit.CR2W/CR2W/CR2WReaderExtensions.cs
+++ b/WolvenKit.CR2W/CR2W/CR2WReaderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -27,10 +27,16 @@ namespace WolvenKit.CR2W
                 var sb = new StringBuilder();
                 while (true)
                 {
-                    var c = (char)file.ReadByte();
-                    if (c == 0)
+                    if (file.BaseStream.Position <= file.BaseStream.Length)
+                    {
+                        var c = (char)file.ReadByte();
+                        if (c == 0)
+                            break;
+                        sb.Append(c);
+                    } else
+                    {
                         break;
-                    sb.Append(c);
+                    }
                 }
                 str = sb.ToString();
             }

--- a/WolvenKit.Wwise/SoundCache/Sound_Cache.cs
+++ b/WolvenKit.Wwise/SoundCache/Sound_Cache.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.MemoryMappedFiles;
@@ -250,6 +250,10 @@ namespace WolvenKit.Cache
                     DataOffset += 0x10;
                     for (int i = 0; i < data_array.Count; i++)
                         data_array[i].PageOffset = -1;
+                }
+                else
+                {
+                    Version = 1;
                 }
 
                 if (buffersize <= CACHE_BUFFER_SIZE)

--- a/WolvenKit.Wwise/Wwise/WemFile.cs
+++ b/WolvenKit.Wwise/Wwise/WemFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 
@@ -278,7 +278,7 @@ namespace WolvenKit.Wwise.Wwise
                         case "LIST":
                             {
                                 LIST_offset = chunk_offset + 8;
-                                LIST_offset = size;
+                                LIST_size = size;
                                 break;
                             }
                         case "smpl":
@@ -299,6 +299,8 @@ namespace WolvenKit.Wwise.Wwise
                                 data_size = size;
                                 break;
                             }
+                        case "hash":
+                            break;
                         default:
                             throw new Exception("Unknown chunk with type: " + type + "!");
                     }
@@ -422,8 +424,8 @@ namespace WolvenKit.Wwise.Wwise
                     br.BaseStream.Seek(LIST_offset, SeekOrigin.Begin);
                     adtlbuf = new String(br.ReadChars(4));
 
-                    if (adtlbuf != "adtl")
-                        throw new Exception("List is not adtl!");
+                    //if (adtlbuf != "adtl")
+                    //    throw new Exception("List is not adtl!");
 
                     LIST_remain = br.ReadBytes((int)(LIST_size - 4));
                 }

--- a/WolvenKit/Forms/MVVM/frmMain.cs
+++ b/WolvenKit/Forms/MVVM/frmMain.cs
@@ -2236,7 +2236,8 @@ namespace WolvenKit
                 return;
 
             // check path length
-            if (MainController.Get().Configuration.DepotPath.Length > 38)
+            //if (MainController.Get().Configuration.DepotPath.Length > 38)
+            if (MainController.Get().Configuration.DepotPath.Length > 255)
             {
                 MainController.LogString("Wcc probably does not support path lengths > 255. " +
                                          "Please move your wcc_lite Modkit directory closer to root, e.g. C:\\Modkit\\.", Common.Services.Logtype.Error);

--- a/WolvenKit/Forms/frmWelcome.cs
+++ b/WolvenKit/Forms/frmWelcome.cs
@@ -1,4 +1,4 @@
-﻿using BrightIdeasSoftware;
+using BrightIdeasSoftware;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -107,10 +107,11 @@ namespace WolvenKit.Forms
         </style> 
     </head>
     <body>
+        <li><a href = ${"\"https://www.nexusmods.com/witcher3/mods/3161\""}> Features and Guidelines </a></li>
         <li><a href = ${"\"https://github.com/Traderain/Wolven-kit/wiki\""}> WolvenKit Wiki </a></li>
         <li><a href = ${"\"https://github.com/WolvenKit/WolvenKit-7\""}> GitHub Repository </a></li>
         <li><a href = ${"\"https://www.youtube.com/watch?v=jUoamicYtjk\""}> Package creation </a></li>
-        <li><a href = ${"\"https://www.youtube.com/watch?v=jUoamicYtjk\""}> Sound modding </a></li>
+        <li><a href = ${"\"https://youtu.be/0Ef-HkEhdv8\""}> Sound modding </a></li>
     </body>
 </html>
           ";
@@ -149,7 +150,9 @@ namespace WolvenKit.Forms
             wolvenKitLbl.ForeColor = UIController.GetForeColor();
 
             helpWebBrowser.DocumentText = DocumentText;
+            helpWebBrowser.Navigating += HelpWebBrowser_Navigating;
         }
+
 
         public const int WM_NCLBUTTONDOWN = 0xA1;
         public const int HT_CAPTION = 0x2;
@@ -158,8 +161,14 @@ namespace WolvenKit.Forms
         public static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         public static extern bool ReleaseCapture();
-      
+
         // UI Events //
+
+        private void HelpWebBrowser_Navigating(object sender, WebBrowserNavigatingEventArgs e)
+        {
+            e.Cancel = true;
+            Process.Start(e.Url.ToString());
+        }
         
         private void mainMenuStrip_MouseDown(object sender, MouseEventArgs e)
         {


### PR DESCRIPTION
# packing and installing mods after exporting wem files

Implemented:
- Fixed incorrect writing format into soundcache files, where data was sometimes written in 64 bits instead of 32 bits.
- Add extra safety checks at stream operations related to soundcache.

Fixed:
- #35

# Additional notes

- Updated welcome form's webbrowser links to remain up to date.
- Packing .bnk files will not always work due to different versions.
