### PR TITLE
Custom class fixes and re-enabling of the flow diagram

### DIFF
--- a/WolvenKit.CR2W/CR2WManager.cs
+++ b/WolvenKit.CR2W/CR2WManager.cs
@@ -174,13 +174,17 @@ namespace WolvenKit.CR2W
 
 
 
-        private const string header = @"
+        private const string header1 = @"
 using System.IO;
 using FastMember;
 using WolvenKit.CR2W.Reflection;
 using static WolvenKit.CR2W.Types.Enums;
 
 
+namespace WolvenKit.CR2W
+{
+";
+        private const string header2 = @"
 namespace WolvenKit.CR2W.Types
 {
 ";
@@ -210,7 +214,7 @@ namespace WolvenKit.CR2W.Types
             using (StringWriter sw = new StringWriter())
             {
                 // usings and namespace
-                sw.WriteLine(header);
+                sw.WriteLine(header1);
 
                 FileInfo[] projectScriptFiles = m_projectinfo.GetFiles("*.ws", SearchOption.AllDirectories);
 
@@ -289,6 +293,8 @@ namespace WolvenKit.CR2W.Types
                 }
                 #endregion
                 sw.WriteLine("\t}\r\n");
+                sw.WriteLine("}\r\n");
+                sw.WriteLine(header2);
 
                 // interpret classes
                 #region Classes

--- a/WolvenKit.CR2W/Reflection/REDReflection.cs
+++ b/WolvenKit.CR2W/Reflection/REDReflection.cs
@@ -1,4 +1,4 @@
-﻿using DotNetHelper.FastMember.Extension.Extension;
+using DotNetHelper.FastMember.Extension.Extension;
 using FastMember;
 using System;
 using System.Collections.Generic;
@@ -123,6 +123,8 @@ namespace WolvenKit.CR2W.Reflection
                 case "float": return "CFloat";
                 case "String": return "CString";
                 case "string": return "CString";
+                case "Name": return "CName";
+                case "name": return "CName";
                 case "Color": return "CColor";
                 case "Matrix": return "CMatrix";
                 default:

--- a/WolvenKit.CR2W/Types/Generic/CPtr.cs
+++ b/WolvenKit.CR2W/Types/Generic/CPtr.cs
@@ -23,7 +23,7 @@ namespace WolvenKit.CR2W.Types
         #region Properties
 
         public CR2WExportWrapper Reference { get; set; }
-        public string ReferenceType => REDType.Split(':').Last();
+        public string ReferenceType => Reference.REDType.Split(':').Last();
         #endregion
 
         #region Methods

--- a/WolvenKit.CR2W/Types/Generic/CPtr.cs
+++ b/WolvenKit.CR2W/Types/Generic/CPtr.cs
@@ -23,23 +23,23 @@ namespace WolvenKit.CR2W.Types
         #region Properties
 
         public CR2WExportWrapper Reference { get; set; }
-        public string ReferenceType => Reference.REDType.Split(':').Last();
+        public string ReferenceType => REDType.Split(':').Last();
         #endregion
 
         #region Methods
         public string GetPtrTargetType()
         {
-            return ReferenceType;
-            //try
-            //{
-            //    if (Reference == null)
-            //        return "NULL";
-            //    return Reference.REDType;
-            //}
-            //catch (Exception ex)
-            //{
-            //    throw new InvalidPtrException(ex.Message);
-            //}
+            //return ReferenceType;
+            try
+            {
+                if (Reference == null)
+                    return "NULL";
+                return Reference.REDType;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidPtrException(ex.Message);
+            }
         }
 
         /// <summary>

--- a/WolvenKit/Forms/Dialog/frmAddChunk.cs
+++ b/WolvenKit/Forms/Dialog/frmAddChunk.cs
@@ -9,8 +9,12 @@ namespace WolvenKit
 {
     public partial class frmAddChunk : Form
     {
-        private string[] classTypes = null;
-        private string[] enumTypes = null;
+        //private string[] classTypes = null;
+        //private string[] enumTypes = null;
+        private List<string> vanillaClasses = null;
+        private List<string> customClasses = null;
+        private List<string> vanillaEnums = null;
+        private List<string> customEnums = null;
         public frmAddChunk(List<string> list = null, bool isVariant = false, bool allowEditName = false)
         {
             InitializeComponent();
@@ -24,16 +28,20 @@ namespace WolvenKit
             {
                 txName.Enabled = false;
             }
-            if (list == null)
+            if (vanillaClasses == null)
             {
-                list = AssemblyDictionary.TypeNames;
+                vanillaClasses = AssemblyDictionary.TypeNames;
             }
-            list.Sort();
-            classTypes = list.ToArray();
+            vanillaClasses.Sort();
 
-            list = AssemblyDictionary.EnumNames;
-            list.Sort();
-            enumTypes = list.ToArray();
+            customClasses = CR2WManager.TypeNames;
+            customClasses.Sort();
+
+
+            vanillaEnums = AssemblyDictionary.EnumNames;
+            vanillaEnums.Sort();
+            customEnums = CR2WManager.EnumNames;
+            customEnums.Sort();
             UpdateTypeChoices();
         }
 
@@ -42,11 +50,11 @@ namespace WolvenKit
             txType.Items.Clear();
             if (checkEnum.Checked)
             {
-                txType.Items.AddRange(enumTypes);
+                txType.Items.AddRange(vanillaEnums.Concat(customEnums).Distinct().ToArray());
             }
             else
             {
-                txType.Items.AddRange(classTypes);
+                txType.Items.AddRange(vanillaClasses.Concat(customClasses).Distinct().ToArray());
             }
             if (txType.SelectedIndex < 0 && txType.Items.Count > 0)
                 txType.SelectedIndex = 0;

--- a/WolvenKit/Forms/Dialog/frmAddChunk.cs
+++ b/WolvenKit/Forms/Dialog/frmAddChunk.cs
@@ -1,16 +1,17 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using WolvenKit.CR2W;
 using WolvenKit.CR2W.Types;
 using WolvenKit.CR2W.Reflection;
+using System.Windows.Documents;
 
 namespace WolvenKit
 {
     public partial class frmAddChunk : Form
     {
-        //private string[] classTypes = null;
-        //private string[] enumTypes = null;
+        private string[] classTypes = null;
+        private string[] enumTypes = null;
         private List<string> vanillaClasses = null;
         private List<string> customClasses = null;
         private List<string> vanillaEnums = null;
@@ -28,20 +29,24 @@ namespace WolvenKit
             {
                 txName.Enabled = false;
             }
-            if (vanillaClasses == null)
+            if (list == null)
             {
-                vanillaClasses = AssemblyDictionary.TypeNames;
+                list = AssemblyDictionary.TypeNames;
             }
-            vanillaClasses.Sort();
+            list.Sort();
 
             customClasses = CR2WManager.TypeNames;
             customClasses.Sort();
 
+            classTypes = list.Concat(customClasses).Distinct().ToArray();
 
             vanillaEnums = AssemblyDictionary.EnumNames;
             vanillaEnums.Sort();
             customEnums = CR2WManager.EnumNames;
             customEnums.Sort();
+
+            enumTypes = vanillaEnums.Concat(customEnums).Distinct().ToArray();
+
             UpdateTypeChoices();
         }
 
@@ -50,11 +55,11 @@ namespace WolvenKit
             txType.Items.Clear();
             if (checkEnum.Checked)
             {
-                txType.Items.AddRange(vanillaEnums.Concat(customEnums).Distinct().ToArray());
+                txType.Items.AddRange(enumTypes);
             }
             else
             {
-                txType.Items.AddRange(vanillaClasses.Concat(customClasses).Distinct().ToArray());
+                txType.Items.AddRange(classTypes);
             }
             if (txType.SelectedIndex < 0 && txType.Items.Count > 0)
                 txType.SelectedIndex = 0;

--- a/WolvenKit/Forms/MVVM/frmCR2WDocument.cs
+++ b/WolvenKit/Forms/MVVM/frmCR2WDocument.cs
@@ -518,12 +518,12 @@ namespace WolvenKit
                 case ".w2quest":
                 case ".w2phase":
                     {
-                        //this.flowDiagram = new frmChunkFlowDiagram();
-                        //this.flowDiagram.OnOutput += MainController.LogString;
-                        //this.flowDiagram.File = this.File;
-                        //this.flowDiagram.DockAreas = DockAreas.Document;
-                        //this.flowDiagram.OnSelectChunk += this.frmCR2WDocument_OnSelectChunk;
-                        //this.flowDiagram.Show(this.FormPanel, DockState.Document);
+                        this.flowDiagram = new frmChunkFlowDiagram();
+                        this.flowDiagram.OnOutput += MainController.LogString;
+                        this.flowDiagram.File = this.File;
+                        this.flowDiagram.DockAreas = DockAreas.Document;
+                        this.flowDiagram.OnSelectChunk += this.frmCR2WDocument_OnSelectChunk;
+                        this.flowDiagram.Show(this.FormPanel, DockState.Document);
                         break;
                     }
 

--- a/WolvenKit/Forms/frmChunkFlowDiagram.cs
+++ b/WolvenKit/Forms/frmChunkFlowDiagram.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -51,7 +51,6 @@ namespace WolvenKit
         public frmChunkFlowDiagram()
         {
             InitializeComponent();
-
             selectionBackground = new SolidBrush(Color.FromArgb(100, SystemColors.Highlight));
             selectionBorder = new Pen(Color.FromArgb(200, SystemColors.Highlight));
             selectionItemHighlight = new Pen(Color.Green, 2.0f);
@@ -292,7 +291,7 @@ namespace WolvenKit
                     // eat the exception, allready logging the exception when creating the node editor
                 }
 
-                if (conns != null)
+                if (conns != null && !isMoving)
                 {
                     foreach (var conn in conns)
                     {


### PR DESCRIPTION
# Pull request template

Custom class fixes and re-enabling of the flow diagram

Implemented:
- Re-enabled the flow diagram in Wkit 7.x

Fixed:
- Fix variable declarations in custom classes with type "name" rather than forcing use of CName which is not common
- Fix variable declarations with vanilla enum types(stopgap fix). Namespace for vanilla enum class needs to be sorted out.
- Fix custom class and enum types not appearing in Add Chunk dialog. You can now actually add chunks with your custom classes. Adding enum variables whether custom or vanilla still may cause issues due to namespace issue described above.
- Fix flow diagram not showing any chunks in Wkit 7.x. ReferenceType now actually returns RedType from Reference.
- Tried to improve flow diagram performance by not drawing connections when panning


I know the flow diagram is slow and probably unusable in big phases but many member of the modding community still find it useful. I have brought it back for them. I hope we can eventually do a proper rewrite of it as these quest were just not meant to be edited in a list. I have also fixed any remaining issues with custom classes so now they can actually be compiled and added with no headache. No more having Wkit 7, 6, 0.3 and W3Edit on your PC just to make a custom classes work.
