### PR TITLE
fix: Urgent hotfix for adding chunks

### DIFF
--- a/WolvenKit/Forms/Dialog/frmAddChunk.cs
+++ b/WolvenKit/Forms/Dialog/frmAddChunk.cs
@@ -36,16 +36,33 @@ namespace WolvenKit
             list.Sort();
 
             customClasses = CR2WManager.TypeNames;
-            customClasses.Sort();
-
-            classTypes = list.Concat(customClasses).Distinct().ToArray();
+            
+            if (customClasses?.Any() == true)
+            {
+                customClasses.Sort();
+                classTypes = list.Concat(customClasses).Distinct().ToArray();
+            }
+            else
+            {
+                classTypes = list.ToArray();
+            }
+            
 
             vanillaEnums = AssemblyDictionary.EnumNames;
             vanillaEnums.Sort();
             customEnums = CR2WManager.EnumNames;
-            customEnums.Sort();
+            
 
-            enumTypes = vanillaEnums.Concat(customEnums).Distinct().ToArray();
+            if (customEnums?.Any() == true)
+            {
+                customEnums.Sort();
+                enumTypes = vanillaEnums.Concat(customEnums).Distinct().ToArray();
+            }
+            else
+            {
+                enumTypes = vanillaEnums.ToArray();
+            }
+
 
             UpdateTypeChoices();
         }


### PR DESCRIPTION
Fixed added new chunks not working when WolvenKit did not have any custom assemblies registered.

# Pull request template

Urgent hotfix for adding chunks when no custom classes are registered

Implemented:
- <Features implemented>

Fixed:
- Fixed adding chunks not working when no custom classes are registered

Made a mistake when fixing no custom class chunks in add chunk dialog. Added if statement to check if custom classes are even registered before concatenating arrays.
